### PR TITLE
Typo fix in app.rb

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -15,7 +15,7 @@ class App < Sinatra::Base
   end
 
   get '/first_exercise' do
-    "Your first exercise will be to set your session key-value pair.\nIn the route: get '/set', write a line of code that sets the :foo key of the session hash equal to 'hello'.\nThen, naviate to the '/set' path."
+    "Your first exercise will be to set your session key-value pair.\nIn the route: get '/set', write a line of code that sets the :foo key of the session hash equal to 'hello'.\nThen, navigate to the '/set' path."
   end
 
   get '/set' do


### PR DESCRIPTION
Typo fix in student instructions of "naviate" to "navigate"